### PR TITLE
Add  "home assistant" to package.json keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "keywords": [
     "node-red",
     "home-assistant",
+    "home assistant",
     "home automation"
   ],
   "node-red": {


### PR DESCRIPTION
When searching for "home assistant" in node-RED palette manager, this node doesn't show up. I'm hoping this change means it will and allow other to find it easily.